### PR TITLE
AMB-1119: add resolved clinical status manually after conversion

### DIFF
--- a/docker/Transformation-Engine/src/main/kotlin/net/nhsd/fhir/converter/transformer/careconnect_transformers.kt
+++ b/docker/Transformation-Engine/src/main/kotlin/net/nhsd/fhir/converter/transformer/careconnect_transformers.kt
@@ -77,6 +77,9 @@ internal const val CARECONNECT_EVIDENCE_URL =
 internal const val UKCORE_EVIDENCE_URL =
     "https://fhir.hl7.org.uk/StructureDefinition/Extension-UKCore-Evidence"
 
+internal const val CARECONNECT_GPC_ALLERGY_INTOLERANCE_END_URL =
+    "https://fhir.nhs.uk/STU3/StructureDefinition/Extension-CareConnect-GPC-AllergyIntoleranceEnd-1"
+
 internal val careconnectTransformers: HashMap<String, ExtensionTransformer> = hashMapOf(
     CARECONNECT_REPEAT_INFORMATION_URL to ::repeatInformation,
     CARECONNECT_GPC_REPEAT_INFORMATION_URL to ::repeatInformation,
@@ -91,7 +94,18 @@ internal val careconnectTransformers: HashMap<String, ExtensionTransformer> = ha
     CARECONNECT_EVIDENCE_URL to ::evidence,
     CARECONNECT_ALLERGY_ASSOCIATED_ENCOUNTER_URL to ::associatedEncounter,
     CARECONNECT_ALLERGY_INTOLERANCE_END_URL to ::allergyIntoleranceEnd,
+    CARECONNECT_GPC_ALLERGY_INTOLERANCE_END_URL to :: allergyIntoleranceEndGPC
 )
+fun allergyIntoleranceEndGPC(src: R3Extension, tgt: R4DomainResource){
+    // handle the conversion of resolved clinicalStatus
+    val resolvedCodeableConcept = R4CodeableConcept().apply {
+        val r4Coding = R4Coding()
+        r4Coding.system = "http://terminology.hl7.org/CodeSystem/allergyintolerance-clinical"
+        r4Coding.code = "resolved"
+        this.coding = listOf(r4Coding)
+    }
+    (tgt as R4AllergyIntolerance).clinicalStatus = resolvedCodeableConcept
+}
 
 fun repeatInformation(src: R3Extension, tgt: R4DomainResource) {
     val ext = R4Extension().apply {

--- a/docker/Transformation-Engine/src/test/kotlin/net/nhsd/fhir/converter/transformer/resolvedAllergies_test.kt
+++ b/docker/Transformation-Engine/src/test/kotlin/net/nhsd/fhir/converter/transformer/resolvedAllergies_test.kt
@@ -1,0 +1,27 @@
+package net.nhsd.fhir.converter.transformer
+
+
+import org.assertj.core.api.Assertions
+import org.hl7.fhir.dstu3.model.Extension
+import org.junit.jupiter.api.Test
+import org.hl7.fhir.r4.model.AllergyIntolerance as R4AllergyIntolerance
+
+class ResolvedAllergiesTest {
+    @Test
+    internal fun `it should add clinicalStatus resolved to resources with gpc allergy end extension`() {
+        // Given
+        // R3 allergy end extension
+        val r3Extension = Extension().apply {
+            url = CARECONNECT_GPC_ALLERGY_INTOLERANCE_END_URL
+        }
+
+        val r4Resource = R4AllergyIntolerance()
+
+        // When transformer is called
+        allergyIntoleranceEndGPC(r3Extension, r4Resource)
+
+        // Then
+        val clinicalStatus = r4Resource.clinicalStatus.coding[0].code
+        Assertions.assertThat(clinicalStatus).isEqualTo("resolved")
+    }
+}


### PR DESCRIPTION
## Summary
Workaround to manually add resolved clinicalStatus to allergyIntolerance resources while issue https://github.com/hapifhir/org.hl7.fhir.core/issues/792 is unresolved


## Reviews Required
* [x] Dev
* [ ] Test
* [ ] Tech Author
* [ ] Product Owner


## Review Checklist
:information_source: This section is to be filled in by the **reviewer**.

* [ ] I have reviewed the changes in this PR and they fill all or part of the acceptance criteria of the ticket, and the code is in a mergeable state.
* [ ] If there were infrastructure, operational, or build changes, I have made sure there is sufficient evidence that the changes will work.
* [ ] I have ensured the changelog has been updated by the submitter, if necessary.
